### PR TITLE
fix: rollback https-proxy-agent version

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@rimiti/stimmy": "1.9.0",
     "axios": "0.24.0",
     "http-proxy-agent": "4.0.1",
-    "https-proxy-agent": "5.0.0"
+    "https-proxy-agent": "4.0.0"
   },
   "devDependencies": {
     "@types/jest": "27.0.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "types": "dist/index.d.ts",
   "license": "GPL-3.0",
   "dependencies": {
-    "@rimiti/stimmy": "1.9.0",
+    "@rimiti/stimmy": "1.10.0",
     "axios": "0.24.0",
     "http-proxy-agent": "4.0.1",
     "https-proxy-agent": "4.0.0"

--- a/src/classes/providers/base/types.ts
+++ b/src/classes/providers/base/types.ts
@@ -1,4 +1,4 @@
-import { HttpsProxyAgent } from 'https-proxy-agent';
+import * as HttpsProxyAgent from 'https-proxy-agent';
 import { HttpProxyAgent } from 'http-proxy-agent';
 import { AxiosRequestConfig } from 'axios';
 

--- a/src/classes/providers/luminati/index.ts
+++ b/src/classes/providers/luminati/index.ts
@@ -1,5 +1,5 @@
 import { AxiosInstance, AxiosPromise, AxiosRequestConfig } from 'axios';
-import { HttpsProxyAgent } from 'https-proxy-agent';
+import * as HttpsProxyAgent from 'https-proxy-agent';
 import { HttpProxyAgent } from 'http-proxy-agent';
 import { ICreateProxyConfig, EStrategyMode } from '../base/types';
 import { replacer } from '../../../utils/replacer';

--- a/src/classes/providers/proxyrack/index.ts
+++ b/src/classes/providers/proxyrack/index.ts
@@ -1,5 +1,5 @@
 import { AxiosPromise, AxiosRequestConfig } from 'axios';
-import { HttpsProxyAgent } from 'https-proxy-agent';
+import * as HttpsProxyAgent from 'https-proxy-agent';
 import { HttpProxyAgent } from 'http-proxy-agent';
 import { EStrategyMode, ICreateProxyConfig } from '../base/types';
 import { replacer } from '../../../utils/replacer';

--- a/src/classes/providers/shifter/index.ts
+++ b/src/classes/providers/shifter/index.ts
@@ -1,5 +1,5 @@
 import { AxiosInstance, AxiosPromise, AxiosRequestConfig } from 'axios';
-import { HttpsProxyAgent } from 'https-proxy-agent';
+import * as HttpsProxyAgent from 'https-proxy-agent';
 import { HttpProxyAgent } from 'http-proxy-agent';
 import { ICreateProxyConfig, EStrategyMode, IProviderConfig } from '../base/types';
 import { Base } from '../base';

--- a/src/utils/replacer.ts
+++ b/src/utils/replacer.ts
@@ -1,4 +1,4 @@
-import stimmy from '@rimiti/stimmy';
+import { stimmy } from '@rimiti/stimmy';
 
 const replacer = stimmy();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -537,10 +537,10 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@rimiti/stimmy@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@rimiti/stimmy/-/stimmy-1.9.0.tgz#a4b31fb7cdd0fb7f4cbb7cf27e324d28625865f4"
-  integrity sha512-ZHmlA4JIY2nvMKL4jLD7mt9n1YD8NUdT7UZpWs3LZ6K56WtlC5No3BD9uBOqWoUgFvT8Sl7pCZ4WrO83HCBADg==
+"@rimiti/stimmy@1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@rimiti/stimmy/-/stimmy-1.10.0.tgz#557799ba1d4925c78c5ce726d7bd5914f831071d"
+  integrity sha512-acNPGWoLRw2DaQLerQnDczPilPZjwyZ5CS4W4XqYw+GUz0o1bofuSmu0MvreQHFw+tszSMHNrimMMelymahuFA==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -763,6 +763,11 @@ acorn@^8.2.4, acorn@^8.5.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.5.0.tgz#4512ccb99b3698c752591e9bb4472e38ad43cee2"
   integrity sha512-yXbYeFy+jUuYd3/CDcg2NkIYE991XYX/bje7LmjJigUciaeO1JR4XxXgCIV1/Zc/dRuFEyw1L0pbA+qynJkW5Q==
 
+agent-base@5:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-5.1.1.tgz#e8fb3f242959db44d63be665db7a8e739537a32c"
+  integrity sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==
+
 agent-base@6:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
@@ -1626,7 +1631,15 @@ http-proxy-agent@4.0.1, http-proxy-agent@^4.0.1:
     agent-base "6"
     debug "4"
 
-https-proxy-agent@5.0.0, https-proxy-agent@^5.0.0:
+https-proxy-agent@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz#702b71fb5520a132a66de1f67541d9e62154d82b"
+  integrity sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==
+  dependencies:
+    agent-base "5"
+    debug "4"
+
+https-proxy-agent@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz#e2a90542abb68a762e0a0850f6c9edadfd8506b2"
   integrity sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==


### PR DESCRIPTION
# Changes
* Rolback `https-proxy-agent`'s version

# Notes
`https-proxy-agent` added [typescript support in it version 5](https://github.com/TooTallNate/node-https-proxy-agent/releases). While this is not an issue on the luminator side, it, however, causes a compilation issue on projects using luminator, with the following error:
```
@tictactrip/luminator/dist/classes/providers/base/types.d.ts:12:33 - error TS2694: Namespace 'HttpsProxyAgent' has no exported member 'HttpsProxyAgent'.

12     httpsAgent: HttpsProxyAgent.HttpsProxyAgent;
```
It seems that type resolution does not work since the typescript port, hence a rollback to its plain javascript version.