### PR TITLE
feat: axios-retry

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "@rimiti/stimmy": "1.11.0",
     "axios": "1.6.8",
+    "axios-retry": "4.0.0",
     "http-proxy-agent": "7.0.2",
     "https-proxy-agent": "7.0.4"
   },

--- a/src/classes/providers/base/index.ts
+++ b/src/classes/providers/base/index.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosInstance, AxiosPromise, AxiosRequestConfig } from 'axios';
+import axiosRetry from 'axios-retry';
 import { IBaseConfig } from './types';
 
 export class Base {
@@ -14,6 +15,18 @@ export class Base {
     } else {
       this.axios = axios.create({ proxy: false });
     }
+
+    // Configure axios-retry with sensible defaults and allow overrides from config.retryConfig
+    const defaultRetryOptions = {
+      retries: 3,
+      retryDelay: axiosRetry.exponentialDelay,
+      shouldResetTimeout: true,
+      retryCondition: axiosRetry.isNetworkOrIdempotentRequestError,
+    };
+
+    const retryOptions = config.retryConfig ? { ...defaultRetryOptions, ...config.retryConfig } : defaultRetryOptions;
+
+    axiosRetry(this.axios, retryOptions);
   }
 
   /**

--- a/src/classes/providers/base/types.ts
+++ b/src/classes/providers/base/types.ts
@@ -1,7 +1,7 @@
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { HttpProxyAgent } from 'http-proxy-agent';
 import { AxiosRequestConfig } from 'axios';
-import { IAxiosRetryConfig } from 'axios-retry/dist/esm';
+import { IAxiosRetryConfig } from 'axios-retry';
 
 enum EStrategyMode {
   MANUAL = 'MANUAL',

--- a/src/classes/providers/base/types.ts
+++ b/src/classes/providers/base/types.ts
@@ -1,6 +1,7 @@
 import { HttpsProxyAgent } from 'https-proxy-agent';
 import { HttpProxyAgent } from 'http-proxy-agent';
 import { AxiosRequestConfig } from 'axios';
+import { IAxiosRetryConfig } from 'axios-retry/dist/esm';
 
 enum EStrategyMode {
   MANUAL = 'MANUAL',
@@ -9,6 +10,7 @@ enum EStrategyMode {
 
 interface IBaseConfig {
   axiosConfig?: AxiosRequestConfig;
+  retryConfig?: IAxiosRetryConfig;
 }
 
 interface ICreateProxyConfig {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1125,6 +1125,13 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
 
+axios-retry@4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/axios-retry/-/axios-retry-4.0.0.tgz#d5cb8ea1db18e05ce6f08aa5fe8b2663bba48e60"
+  integrity sha512-F6P4HVGITD/v4z9Lw2mIA24IabTajvpDZmKa6zq/gGwn57wN5j1P3uWrAV0+diqnW6kTM2fTqmWNfgYWGmMuiA==
+  dependencies:
+    is-retry-allowed "^2.2.0"
+
 axios@1.6.8:
   version "1.6.8"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.6.8.tgz#66d294951f5d988a00e87a0ffb955316a619ea66"
@@ -1973,6 +1980,11 @@ is-path-inside@^3.0.3:
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/is-path-inside/-/is-path-inside-3.0.3.tgz#d231362e53a07ff2b0e0ea7fed049161ffd16283"
   integrity sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==
+
+is-retry-allowed@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz#88f34cbd236e043e71b6932d09b0c65fb7b4d71d"
+  integrity sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==
 
 is-stream@^2.0.0:
   version "2.0.1"


### PR DESCRIPTION
## Purpose

This pull request introduces automatic retry logic for HTTP requests made using `axios` by integrating the `axios-retry` library into the base provider class. This enhances the resilience of network requests and allows for customizable retry behavior via configuration options.

**Dependency addition:**

* Added `axios-retry` as a new dependency in `package.json` to enable retry functionality for HTTP requests.

**Base provider improvements:**

* Imported `axios-retry` in `src/classes/providers/base/index.ts` and applied it to the `axios` instance within the `Base` class, using sensible default options (3 retries, exponential backoff, etc.) with the ability to override via configuration. [[1]](diffhunk://#diff-28864e01cf6c9d3bdca668a5f39b538f04888e15e187fabe1653a8cfb6918679R2) [[2]](diffhunk://#diff-28864e01cf6c9d3bdca668a5f39b538f04888e15e187fabe1653a8cfb6918679R18-R29)

**Configuration enhancements:**

* Updated the `IBaseConfig` interface in `src/classes/providers/base/types.ts` to include an optional `retryConfig` property, allowing consumers to customize retry behavior. [[1]](diffhunk://#diff-ee9b3433ed19d3d3bca2199cb3b252d1e405eed6e227ac6d552435f76cac0154R4) [[2]](diffhunk://#diff-ee9b3433ed19d3d3bca2199cb3b252d1e405eed6e227ac6d552435f76cac0154R13)